### PR TITLE
Add a configurable multiplier to the value of unique ships in the museum

### DIFF
--- a/data/config/LunaSettings.csv
+++ b/data/config/LunaSettings.csv
@@ -187,3 +187,4 @@ IndEvo_museum_alphaCoreExtraParades,[Museum] Alpha Core Extra Parades,Int,1,,Ext
 IndEvo_museum_betaCoreIncomePerStability,[Museum] Beta Core Income per Stability,Int,20000,,Amount of required income per +1 stability when a Beta Core is installed.,1,100000,Industries
 IndEvo_museum_betaCoreIncomePerPointImmigration,[Museum] Beta Core Income per Point Immigration,Int,3000,,Amount of required income per +1 immigration when at when a Beta Core is installed.,1,100000,Industries
 IndEvo_museum_gammaCoreIncomeMult,[Museum] Gamma Core Income Multiplier,Double,1.3,,Multiplier applied to total income when a Gamma Core is installed.,0.1,3,Industries
+IndEvo_museum_uniqueShipValueMult,[Museum] Unique Ship Value Multiplier,Double,2,,Multiplier applied to the value of unique ships.,1.0,5,Industries

--- a/jars/src/indevo/industries/museum/data/MuseumConstants.java
+++ b/jars/src/indevo/industries/museum/data/MuseumConstants.java
@@ -34,4 +34,6 @@ public class MuseumConstants {
     public static final int BETA_CORE_INCOME_PER_STABILITY = Settings.getInt(Settings.MUSEUM_BETA_CORE_INCOME_PER_STABILITY);
     public static final int BETA_CORE_INCOME_PER_POINT_IMMIGRATION = Settings.getInt(Settings.MUSEUM_BETA_CORE_INCOME_PER_POINT_IMMIGRATION);
     public static final float GAMMA_CORE_INCOME_MULT = Settings.getFloat(Settings.MUSEUM_GAMMA_CORE_INCOME_MULT);
+
+    public static final float UNIQUE_SHIP_VALUE_MULT = Settings.getFloat(Settings.MUSEUM_UNIQUE_SHIP_VALUE_MULT);
 }

--- a/jars/src/indevo/industries/museum/industry/Museum.java
+++ b/jars/src/indevo/industries/museum/industry/Museum.java
@@ -253,9 +253,14 @@ public class Museum extends BaseIndustry implements EconomyTickListener, MarketI
         Pair<Float, Float> valuePair = hullSizeValueMap.get(member.getHullSpec().getHullSize()); //one = maxShipValue, two = average for hull size
 
         float value = member.getBaseValue();
+        Set<String> tags = member.getHullSpec().getTags();
+        if (tags.contains("no_sell") || tags.contains("no_dealer")) {
+            value *= MuseumConstants.UNIQUE_SHIP_VALUE_MULT;
+        }
         float valueAboveAverage = value - valuePair.two;
         float maxAboveAverage = valuePair.one - valuePair.two;
         float val = MathUtils.clamp(valueAboveAverage / maxAboveAverage, 0, 1);
+
 
         ModPlugin.log("Getting Museum Ship Value: " + member.getHullSpec().getHullId() + "\ncost: " + member.getHullSpec().getBaseValue() + "\nmax / avg " + valuePair.one + " / " + valuePair.two + "\nvalue: " + val);
 

--- a/jars/src/indevo/industries/museum/industry/Museum.java
+++ b/jars/src/indevo/industries/museum/industry/Museum.java
@@ -254,15 +254,14 @@ public class Museum extends BaseIndustry implements EconomyTickListener, MarketI
 
         float value = member.getBaseValue();
         Set<String> tags = member.getHullSpec().getTags();
-        if (tags.contains("no_sell") || tags.contains("no_dealer")) {
+        if (tags.contains("no_sell") && tags.contains("no_dealer")) {
             value *= MuseumConstants.UNIQUE_SHIP_VALUE_MULT;
         }
         float valueAboveAverage = value - valuePair.two;
         float maxAboveAverage = valuePair.one - valuePair.two;
         float val = MathUtils.clamp(valueAboveAverage / maxAboveAverage, 0, 1);
 
-
-        ModPlugin.log("Getting Museum Ship Value: " + member.getHullSpec().getHullId() + "\ncost: " + member.getHullSpec().getBaseValue() + "\nmax / avg " + valuePair.one + " / " + valuePair.two + "\nvalue: " + val);
+        ModPlugin.log("Getting Museum Ship Value: " + member.getHullSpec().getHullId() + "\ncost: " + value + "\nmax / avg " + valuePair.one + " / " + valuePair.two + "\nvalue: " + val);
 
         return val;
     }

--- a/jars/src/indevo/utils/helper/Settings.java
+++ b/jars/src/indevo/utils/helper/Settings.java
@@ -159,6 +159,7 @@ public class Settings {
     public static final String MUSEUM_BETA_CORE_INCOME_PER_STABILITY = "IndEvo_museum_betaCoreIncomePerStability";
     public static final String MUSEUM_BETA_CORE_INCOME_PER_POINT_IMMIGRATION = "IndEvo_museum_betaCoreIncomePerPointImmigration";
     public static final String MUSEUM_GAMMA_CORE_INCOME_MULT = "IndEvo_museum_gammaCoreIncomeMult";
+    public static final String MUSEUM_UNIQUE_SHIP_VALUE_MULT = "IndEvo_museum_uniqueShipValueMult";
 
     public static boolean getBoolean(String s){
         if (Global.getSettings().getModManager().isModEnabled("lunalib")) {


### PR DESCRIPTION
Uniqueness is evaluated based on having the `no_sell`, `no_dealer` tags. Made specifically because of the unique (aka, only 1 instance exists per sector) Buffalo reskin from JaydeePiracy that would otherwise be valued as low as a regular buffalo.

I'm not opposed to having the setting be 1 by default if you feel like it's OP in some situations.